### PR TITLE
fix(#13): make product image field optional

### DIFF
--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -5,7 +5,7 @@ export const productSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional().nullable(),
   price: z.number().nonnegative(),
-  image_url: z.string().url().optional().nullable(),
+  image_url: z.string().url().or(z.literal("")).optional().nullable(),
 });
 
 export const clientSchema = z.object({


### PR DESCRIPTION
## Summary
- Fixed validation schema to allow products to be created without an image
- Changed `image_url` field to accept empty strings in addition to valid URLs or null values

## Changes
- Updated `src/lib/validation.ts` to use `.or(z.literal(""))` for the image_url field

## Test Plan
- [x] Build passes successfully
- [x] Verify product creation works without uploading an image
- [x] Verify product creation still works when an image is uploaded
- [x] Verify editing products maintains proper image handling

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)