### PR TITLE
feat(#24): add VAT labels to all price displays

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -18,7 +18,9 @@
     "saving": "Saving…",
     "uploading": "Uploading…",
     "preview": "Preview",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "vatExcluded": "ex VAT",
+    "vatIncluded": "inc VAT"
   },
   "Products": {
     "title": "Your products",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -18,7 +18,9 @@
     "saving": "Enregistrement…",
     "uploading": "Téléversement…",
     "preview": "Aperçu",
-    "cancel": "Annuler"
+    "cancel": "Annuler",
+    "vatExcluded": "HT",
+    "vatIncluded": "TTC"
   },
   "Products": {
     "title": "Vos produits",

--- a/src/app/(app)/invoices/[id]/page.tsx
+++ b/src/app/(app)/invoices/[id]/page.tsx
@@ -125,7 +125,7 @@ export default function InvoiceDetailPage({
               {t("detail.total")}
             </h2>
             <p className="text-2xl font-semibold">
-              {centsToCurrencyString(total, "EUR", APP_LOCALE)}
+              {centsToCurrencyString(total, "EUR", APP_LOCALE)} {c("vatExcluded")}
             </p>
           </div>
         </div>
@@ -145,11 +145,11 @@ export default function InvoiceDetailPage({
                     <div className="font-medium text-gray-900">{it.name}</div>
                     <div className="text-gray-500">
                       {t("detail.qty")} {it.quantity} ×{" "}
-                      {centsToCurrencyString(it.price, "EUR", APP_LOCALE)}
+                      {centsToCurrencyString(it.price, "EUR", APP_LOCALE)} {c("vatExcluded")}
                     </div>
                   </div>
                   <div className="font-semibold">
-                    {centsToCurrencyString(it.total, "EUR", APP_LOCALE)}
+                    {centsToCurrencyString(it.total, "EUR", APP_LOCALE)} {c("vatExcluded")}
                   </div>
                 </div>
               ))}

--- a/src/app/(app)/invoices/new/page.tsx
+++ b/src/app/(app)/invoices/new/page.tsx
@@ -342,7 +342,7 @@ export default function NewInvoicePage() {
       <div className="fixed inset-x-0 bottom-0 z-10 border-t bg-background p-3">
         <div className="flex items-center justify-between px-2">
           <div className="text-lg font-medium">
-            {t("new.total")} {centsToCurrencyString(totalAmount, "EUR", APP_LOCALE)}
+            {t("new.total")} {centsToCurrencyString(totalAmount, "EUR", APP_LOCALE)} {c("vatExcluded")}
           </div>
           <div className="flex gap-2">
             <Button

--- a/src/app/(app)/invoices/page.tsx
+++ b/src/app/(app)/invoices/page.tsx
@@ -10,6 +10,7 @@ import { APP_LOCALE } from "@/lib/constants";
 async function InvoicesList() {
   const invoices = await listInvoices();
   const t = await getTranslations("Invoices");
+  const c = await getTranslations("Common");
   return (
     <div className="space-y-3">
       {invoices.map(
@@ -51,7 +52,7 @@ async function InvoicesList() {
                   <div className="flex items-center gap-3">
                     <div className="text-right">
                       <p className="font-semibold text-lg text-gray-900">
-                        {total}
+                        {total} {c("vatExcluded")}
                       </p>
                     </div>
                   </div>

--- a/src/app/(app)/products/page.tsx
+++ b/src/app/(app)/products/page.tsx
@@ -36,7 +36,7 @@ async function ProductsList() {
               <div>
                 <p className="font-medium">{p.name}</p>
                 <p className="text-sm text-muted-foreground">
-                  {p.price != null ? centsToCurrencyString(p.price, "EUR", APP_LOCALE) : "N/A"}
+                  {p.price != null ? `${centsToCurrencyString(p.price, "EUR", APP_LOCALE)} ${c("vatExcluded")}` : "N/A"}
                 </p>
               </div>
             </div>

--- a/src/components/invoices/ArticlesBlock.tsx
+++ b/src/components/invoices/ArticlesBlock.tsx
@@ -47,6 +47,7 @@ export default function ArticlesBlock({
   onChangePriceAction,
 }: ArticlesBlockProps) {
   const t = useTranslations("Invoices");
+  const c = useTranslations("Common");
 
   return (
     <div>
@@ -118,7 +119,7 @@ export default function ArticlesBlock({
                 {/* Total and Delete Button */}
                 <div className="flex items-center justify-between pt-2">
                   <div className="text-sm font-medium">
-                    Total: {centsToCurrencyString(it.total, "EUR", APP_LOCALE)}
+                    Total: {centsToCurrencyString(it.total, "EUR", APP_LOCALE)} {c("vatExcluded")}
                   </div>
                   <Button
                     size="sm"


### PR DESCRIPTION
## Summary
This PR addresses issue #24 by adding explicit VAT labeling to all price displays throughout the application.

### Changes made:
- Added translation keys for VAT labels (`vatExcluded` = "HT" in French, "ex VAT" in English)
- Updated all price displays to include VAT status labels:
  - Products list page
  - New Invoice page (total)
  - Invoice creation ArticlesBlock (line totals)
  - Invoices list page (totals)
  - Invoice detail page (total, unit prices, and line totals)

### Important note:
All prices currently shown in the UI are **excluding VAT (HT/ex VAT)**. The VAT (20%) is only calculated and displayed in the generated PDF invoice.

## Test plan
- [x] Build passes successfully
- [x] Linting passes
- [x] Manually test Products page to verify price labels appear
- [x] Manually test Invoice creation flow to verify labels on line totals and bottom total
- [x] Manually test Invoice list page to verify total labels
- [x] Manually test Invoice detail page to verify all price labels (total, unit prices, line totals)
- [x] Verify labels display correctly in both French (HT) and English (ex VAT)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)