### PR TITLE
feat(#44): enhance list loading states with skeleton loaders across all entity views

### DIFF
--- a/src/app/(app)/clients/page.tsx
+++ b/src/app/(app)/clients/page.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { ClientFieldGroup } from "@/components/clients/ClientFieldGroup";
 import { ClientListItem } from "@/components/clients/ClientListItem";
+import { ClientListItemSkeleton } from "@/components/clients/ClientListItemSkeleton";
 import { useClientForm } from "@/components/clients/useClientForm";
 import { Button } from "@/components/ui/button";
 import { SheetItem } from "@/components/ui/item/SheetItem";
@@ -48,16 +49,16 @@ export default function ClientsPage() {
     void loadClients();
   };
 
-  if (loading) {
-    return <div className="p-4">Loading...</div>;
-  }
-
   return (
     <>
       <div className="flex flex-col gap-2">
-        {clients.map((cItem) => (
-          <ClientListItem key={cItem.id} id={cItem.id} name={cItem.name} />
-        ))}
+        {loading
+          ? Array.from({ length: 5 }).map((_, index) => (
+              <ClientListItemSkeleton key={index} />
+            ))
+          : clients.map((cItem) => (
+              <ClientListItem key={cItem.id} id={cItem.id} name={cItem.name} />
+            ))}
       </div>
 
       <Button

--- a/src/app/(app)/invoices/page.tsx
+++ b/src/app/(app)/invoices/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { InvoiceListItem } from "@/components/invoices/InvoiceListItem";
+import { InvoiceListItemSkeleton } from "@/components/invoices/InvoiceListItemSkeleton";
 import { InvoiceView } from "@/components/invoices/InvoiceView";
 import { useInvoiceForm } from "@/components/invoices/useInvoiceForm";
 import { Button } from "@/components/ui/button";
@@ -48,24 +49,24 @@ export default function InvoicesPage() {
     void loadInvoices();
   };
 
-  if (loading) {
-    return <div className="p-4">Loading...</div>;
-  }
-
   return (
     <>
       <div className="flex flex-col gap-2">
-        {invoices.map((inv) => {
-          return (
-            <InvoiceListItem
-              key={inv.id}
-              id={inv.id}
-              name={inv.clients.name}
-              price={inv.total_amount}
-              number={inv.number}
-            />
-          );
-        })}
+        {loading
+          ? Array.from({ length: 5 }).map((_, index) => (
+              <InvoiceListItemSkeleton key={index} />
+            ))
+          : invoices.map((inv) => {
+              return (
+                <InvoiceListItem
+                  key={inv.id}
+                  id={inv.id}
+                  name={inv.clients.name}
+                  price={inv.total_amount}
+                  number={inv.number}
+                />
+              );
+            })}
       </div>
 
       <Button

--- a/src/app/(app)/products/page.tsx
+++ b/src/app/(app)/products/page.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { ProductFieldGroup } from "@/components/products/ProductFieldGroup";
 import { ProductListItem } from "@/components/products/ProductListItem";
+import { ProductListItemSkeleton } from "@/components/products/ProductListItemSkeleton";
 import { useProductForm } from "@/components/products/useProductForm";
 import { Button } from "@/components/ui/button";
 import { SheetItem } from "@/components/ui/item/SheetItem";
@@ -49,22 +50,22 @@ export default function ProductsPage() {
     void loadProducts();
   };
 
-  if (loading) {
-    return <div className="p-4">Loading...</div>;
-  }
-
   return (
     <>
       <div className="flex flex-col gap-2">
-        {products.map((p) => (
-          <ProductListItem
-            key={p.id}
-            name={p.name}
-            price={p.price}
-            id={p.id}
-            imageUrl={p.image_url || ""}
-          />
-        ))}
+        {loading
+          ? Array.from({ length: 5 }).map((_, index) => (
+              <ProductListItemSkeleton key={index} />
+            ))
+          : products.map((p) => (
+              <ProductListItem
+                key={p.id}
+                name={p.name}
+                price={p.price}
+                id={p.id}
+                imageUrl={p.image_url || ""}
+              />
+            ))}
       </div>
 
       <Button

--- a/src/components/clients/ClientListItemSkeleton.tsx
+++ b/src/components/clients/ClientListItemSkeleton.tsx
@@ -1,0 +1,23 @@
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemMedia,
+} from "@/components/ui/item";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export const ClientListItemSkeleton = () => {
+  return (
+    <Item variant="outline" size="sm">
+      <ItemMedia variant="image">
+        <Skeleton className="size-8 rounded-full" />
+      </ItemMedia>
+      <ItemContent>
+        <Skeleton className="h-4 w-40" />
+      </ItemContent>
+      <ItemActions>
+        <Skeleton className="size-4" />
+      </ItemActions>
+    </Item>
+  );
+};

--- a/src/components/invoices/InvoiceListItemSkeleton.tsx
+++ b/src/components/invoices/InvoiceListItemSkeleton.tsx
@@ -1,0 +1,27 @@
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemMedia,
+} from "@/components/ui/item";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export const InvoiceListItemSkeleton = () => {
+  return (
+    <Item variant="outline" size="sm">
+      <ItemMedia variant="image">
+        <Skeleton className="size-8 rounded-full" />
+      </ItemMedia>
+      <ItemContent>
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-3 w-24" />
+      </ItemContent>
+      <ItemContent>
+        <Skeleton className="h-4 w-28" />
+      </ItemContent>
+      <ItemActions>
+        <Skeleton className="size-4" />
+      </ItemActions>
+    </Item>
+  );
+};

--- a/src/components/products/ProductListItemSkeleton.tsx
+++ b/src/components/products/ProductListItemSkeleton.tsx
@@ -1,0 +1,24 @@
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemMedia,
+} from "@/components/ui/item";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export const ProductListItemSkeleton = () => {
+  return (
+    <Item variant="outline" size="sm">
+      <ItemMedia>
+        <Skeleton className="h-10 w-10 rounded" />
+      </ItemMedia>
+      <ItemContent>
+        <Skeleton className="h-4 w-36" />
+        <Skeleton className="h-3 w-24" />
+      </ItemContent>
+      <ItemActions>
+        <Skeleton className="size-4" />
+      </ItemActions>
+    </Item>
+  );
+};


### PR DESCRIPTION
## Summary

This PR enhances the loading states across all list views (Invoices, Clients, and Products) by replacing basic "Loading..." text with professional skeleton loaders that match the actual list item structures.

## Changes

### New Components
- ✨ **InvoiceListItemSkeleton** - Skeleton loader matching InvoiceListItem structure (avatar, title, description, price)
- ✨ **ClientListItemSkeleton** - Skeleton loader matching ClientListItem structure (avatar, name)
- ✨ **ProductListItemSkeleton** - Skeleton loader matching ProductListItem structure (image, name, price)

### Updated Pages
- 🔄 **Invoices Page** (`src/app/(app)/invoices/page.tsx`) - Now displays 5 skeleton items while loading
- 🔄 **Clients Page** (`src/app/(app)/clients/page.tsx`) - Now displays 5 skeleton items while loading
- 🔄 **Products Page** (`src/app/(app)/products/page.tsx`) - Now displays 5 skeleton items while loading

## Benefits

- ✅ **Improved UX** - Users see a preview of content structure while loading
- ✅ **Reduced perceived wait time** - Skeleton loaders make loading feel faster
- ✅ **Professional appearance** - Matches modern web app standards
- ✅ **Consistency** - All list views provide the same high-quality loading experience
- ✅ **Visual continuity** - Smooth transition from loading to loaded state

## Test Plan

- [x] Built project successfully with no TypeScript errors
- [x] Verified skeleton components match actual list item structures
- [x] All three list views use consistent skeleton loading pattern
- [x] Skeleton loaders display 5 items during initial page load

## Screenshots

The skeleton loaders will be visible when navigating to:
- `/invoices` - 5 invoice skeletons with avatar, name, number, and price placeholders
- `/clients` - 5 client skeletons with avatar and name placeholders
- `/products` - 5 product skeletons with image, name, and price placeholders

## Implementation Details

- Used existing `Skeleton` component from `src/components/ui/skeleton.tsx`
- Matched `Item` component structure used by actual list items
- Display 5 skeleton items during loading (using `Array.from({ length: 5 })`)
- Skeleton components use same variant and size props as actual items

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)