### PR TITLE
feat(#51): add tooltip to disabled PDF button for better UX

### DIFF
--- a/src/app/(app)/invoices/page.tsx
+++ b/src/app/(app)/invoices/page.tsx
@@ -12,10 +12,12 @@ import { useInvoiceForm } from "@/components/invoices/useInvoiceForm";
 import { ProfileCompletenessAlert } from "@/components/profile/ProfileCompletenessAlert";
 import { Button } from "@/components/ui/button";
 import { SheetItem } from "@/components/ui/item/SheetItem";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { Invoice } from "@/types/models";
 
 export default function InvoicesPage() {
   const tInvoices = useTranslations("Invoices");
+  const tProfile = useTranslations("Profile");
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -101,17 +103,38 @@ export default function InvoicesPage() {
           </>
         }
         footer={
-          <Button
-            onClick={onDownloadInvoice}
-            disabled={
-              downloadingInvoice ||
-              (profileValidation !== null && !profileValidation.isComplete)
-            }
-          >
-            {downloadingInvoice
-              ? tInvoices("detail.downloading")
-              : tInvoices("detail.download")}
-          </Button>
+          profileValidation !== null && !profileValidation.isComplete ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div>
+                  <Button
+                    onClick={onDownloadInvoice}
+                    disabled={true}
+                    className="w-full"
+                  >
+                    {tInvoices("detail.download")}
+                  </Button>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>
+                  {tProfile("completeness.missingFields")}:{" "}
+                  {profileValidation.missingFields
+                    .map((field) => tProfile(`fields.${field}`))
+                    .join(", ")}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <Button
+              onClick={onDownloadInvoice}
+              disabled={downloadingInvoice}
+            >
+              {downloadingInvoice
+                ? tInvoices("detail.downloading")
+                : tInvoices("detail.download")}
+            </Button>
+          )
         }
       />
     </>


### PR DESCRIPTION
## Summary

This PR enhances the user experience when attempting to generate PDFs with an incomplete profile by adding an interactive tooltip to the disabled download button, building upon the existing validation infrastructure from issues #48 and #50.

## Changes Made

### UI Improvements
- ✨ Added `Tooltip` component to disabled PDF download button
- 📝 Tooltip displays specific missing required fields when hovering over disabled button
- 🎨 Maintains existing `ProfileCompletenessAlert` component for broader context in the invoice sheet

### Technical Details
- Imported `Tooltip`, `TooltipContent`, and `TooltipTrigger` from shadcn/ui components
- Added conditional rendering: shows tooltip wrapper when profile is incomplete
- Tooltip content uses existing translations from `Profile.completeness` namespace
- Button wrapping follows accessibility best practices (wrapped in `<div>` for proper tooltip trigger)

## Acceptance Criteria ✓

All requirements from issue #51 have been met:

- [x] **PDF button disabled when profile incomplete**  
  _Button is disabled when `profileValidation.isComplete === false`_

- [x] **Helpful messaging explains what's missing (specific field names)**  
  _Tooltip shows: "Required fields: [field names]"_  
  _ProfileCompletenessAlert provides detailed context_

- [x] **Link to profile page for quick access**  
  _Available in ProfileCompletenessAlert component_

- [x] **Server-side validation prevents API abuse**  
  _Already implemented in `/api/invoices/[id]/pdf` route (lines 37-50)_

- [x] **API returns structured error with field details**  
  _API response includes `missingFields` and `warnings` arrays_

## Implementation Notes

### Existing Infrastructure Used
This PR leverages existing functionality from previous issues:
- `validateProfileForPdfGeneration()` function from #50
- Server-side validation in PDF generation endpoint from #50
- `ProfileCompletenessAlert` component from #50
- `/api/profile/validate` endpoint for client-side checks

### New Code Added
Only minimal UI enhancement was needed:
- Tooltip wrapper around disabled button (~30 lines)
- Additional translation hook for profile messages
- Conditional rendering logic for tooltip vs. normal button

## Testing

### Build Verification
- ✅ `npm run build` passes successfully
- ✅ No TypeScript errors
- ✅ All routes compile correctly

### Manual Testing Checklist
- [ ] Verify tooltip appears when hovering over disabled button
- [ ] Confirm tooltip shows correct missing field names
- [ ] Test that ProfileCompletenessAlert still displays above invoice details
- [ ] Verify "Complete profile" link navigates to `/profil`
- [ ] Test PDF generation is blocked when profile incomplete
- [ ] Verify PDF generation succeeds when profile is complete

## Screenshots

_Add screenshots showing:_
1. Disabled button with tooltip on hover
2. ProfileCompletenessAlert displayed in invoice sheet
3. Error message from API when attempting direct API call with incomplete profile

## Dependencies

This PR depends on:
- ✅ #48 - Define PDF Generation Requirements (merged)
- ✅ #50 - Profile Completeness Validation (merged)

## Related Issues

Closes #51  
Parent issue: #12

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)